### PR TITLE
fix: 🐛 Tags and Topics page generating

### DIFF
--- a/pages/tags/[slug].jsx
+++ b/pages/tags/[slug].jsx
@@ -3,7 +3,7 @@ import { TopicsTagsPage } from '@components/topics_tags';
 
 export const getStaticPaths = staticPathFactory('tags');
 
-export const getStaticProps = categoryStaticPropsFactory('tags');
+export const getStaticProps = categoryStaticPropsFactory('tags', 'tag');
 
 export default function Page({ entry, videoIds }) {
     return <TopicsTagsPage title="Tag" entry={entry} videoIds={videoIds} />;

--- a/pages/topics/[slug].jsx
+++ b/pages/topics/[slug].jsx
@@ -3,7 +3,7 @@ import { TopicsTagsPage } from '@components/topics_tags';
 
 export const getStaticPaths = staticPathFactory('topics');
 
-export const getStaticProps = categoryStaticPropsFactory('topics');
+export const getStaticProps = categoryStaticPropsFactory('topics', 'topic');
 
 export default function Page({ entry, videoIds }) {
     return <TopicsTagsPage title="Topic" entry={entry} videoIds={videoIds} />;

--- a/utils/static.js
+++ b/utils/static.js
@@ -11,14 +11,14 @@ export function staticPathFactory(key) {
     });
 }
 
-export function categoryStaticPropsFactory(category) {
+export function categoryStaticPropsFactory(category, lookup) {
     return async ({ params: { slug } }) => {
         const entry = NAMES_BY_SLUG[category][slug];
 
         return entry ? {
             props: {
                 entry,
-                videoIds: THEOLOGY101_DATA.lookups[category][entry] || [],
+                videoIds: THEOLOGY101_DATA.lookups[lookup][entry] || [],
             },
         } : { notFound: true };
     };


### PR DESCRIPTION
## Status
**READY**

## Description
- Fix Tags and Topics pages generating.

The reason is `topic` and `tag` keys are plural in other places but it is singular in JSON data `lookups`.

## Follow-up
- `lookups` dict keys should also be plural in JSON data.